### PR TITLE
Fixed widget iterator going out of range with ui.Tree

### DIFF
--- a/lib/src/ui/widget_iterators.dart
+++ b/lib/src/ui/widget_iterators.dart
@@ -56,7 +56,7 @@ class _WidgetsIterator<Widget> implements Iterator<Widget> {
   }
 
   bool _hasNext() {
-    return (index < _contained.length);
+    return (index < (_contained.length-1));
   }
 
   Widget _next() {


### PR DESCRIPTION
Hey! 

I would like to thank you for porting over the awesomeness of GWT to Dart, I was really can not get used to how limited WebUI is. 

One question that I have is, did you really have to port the exact event system from GWT? One thing that I hated about GWT is the fact you had 3 different classes for every event; Would it not just be easier to use Dart's Stream feature? 
